### PR TITLE
fix: update build command and fix typo in README (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ mvn jasypt:decrypt-value -Djasypt.encryptor.password="springforge" -Djasypt.plug
 
 - **-Djasypt.encryptor.password="password"**: The password that was used to encrypt the value. You must use the same
   password for decryption.
-- **-Djasypt.plugin.value="encryptor valie"**: The encrypted value that you want to decrypt.
+- **-Djasypt.plugin.value="encryptor value"**: The encrypted value that you want to decrypt.
 
-### **Run the Application**
+### **Build project command**
 
-```sh
-mvn spring-boot:run
+```bash
+mvn clean install -Dspring.profiles.active=<environment> -Djasypt.encryptor.password=<password>
 ```
+**Replace** <environment> with the desired Spring profile (**e.g.**, ```dev```, ```uat```, ```prod```) and <password> with the Jasypt encryption password.
 
 The application will start on `http://localhost:8080`.
 


### PR DESCRIPTION
Update build command and fix typo in README

- Corrected the build command for Spring profiles and Jasypt encryption password.
- Fixed typo "valie" to "value" in the README.